### PR TITLE
feat(service): add ip geolocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
     You can configure the secure tunnel at [dash.cloudflare.com](https://dash.cloudflare.com/).
     
+ - ### `geoip`
+    
+    You cannot access the ip geolocator via a web interface.
+    
  - ### `grafana`
     
     You can access the observation dashboard at [grafana.localhost](https://grafana.localhost/).

--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -107,6 +107,9 @@ services:
     image: adminer:4.8.1-standalone
     volumes:
       - ../production/configurations/adminer/adminer.css:/var/www/html/adminer.css:ro
+  geoip:
+    # You cannot access the ip geolocator via a web interface.
+    image: ghcr.io/observabilitystack/geoip-api:2024-41
   grafana:
     # You can access the observation dashboard at [grafana.localhost](https://grafana.localhost/).
     deploy:


### PR DESCRIPTION
Always pinging ip-api.com is a bit inefficient and slows down all requests that have no timezone attached. We can host an alternative on our own.