### PR TITLE
feat(postgres)!: switch from alpine to debian variant

### DIFF
--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -310,7 +310,7 @@ services:
       POSTGRES_DB_FILE: /run/secrets/postgres_db
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
       POSTGRES_USER_FILE: /run/secrets/postgres_user
-    image: quay.io/debezium/postgres:17-alpine
+    image: quay.io/debezium/postgres:17 # alpine variant does not include PostGIS
     # # Expose ports (only) e.g. to generate a database graph image or similar.
     # ports:
     #   - 5432:5432


### PR DESCRIPTION
The non-alpine variant of Debezium's PostgreSQL container image is obviously larger, but also includes PostGIS which is needed to work with geospatial data.

This is added as breaking change because [afaik Postgres data on disk is not cross-compatible](https://blog.nuvotex.de/postgres-2/).