### PR TITLE
fix(postgres): use official postgis image

### DIFF
--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -325,7 +325,7 @@ services:
       POSTGRES_DB_FILE: /run/secrets/postgres_db
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
       POSTGRES_USER_FILE: /run/secrets/postgres_user
-    image: quay.io/debezium/postgres:17 # alpine variant does not include PostGIS
+    image: postgis/postgis:17-3.5-alpine
     # # Expose ports (only) e.g. to generate a database graph image or similar.
     # ports:
     #   - 5432:5432


### PR DESCRIPTION
Should allow us to continue working after Debezium's images lost their arm64 variant.

cc @huzaifaedhi22