### PR TITLE
fix(grafana): set root url

### DIFF
--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -157,6 +157,8 @@ services:
         - traefik.http.routers.grafana_secure.rule=Host(`grafana.${STACK_DOMAIN}`)
         - traefik.http.routers.grafana_secure.tls.options=mintls13@file #DARGSTACK-REMOVE
         - traefik.http.services.grafana.loadbalancer.server.port=3000
+    environment:
+      GF_SERVER_ROOT_URL: https://grafana.${STACK_DOMAIN}/
     image: grafana/grafana:12.0.1
     secrets:
       - postgres_db

--- a/src/production/configurations/grafana/grafana.ini
+++ b/src/production/configurations/grafana/grafana.ini
@@ -4,9 +4,6 @@ password = $__file{/run/secrets/postgres_role_service_grafana_password}
 type = postgres
 user = $__file{/run/secrets/postgres_role_service_grafana_username}
 
-[paths]
-provisioning = /etc/configurations/provisioning
-
 [security]
 admin_email = $__file{/run/secrets/grafana_admin_email}
 admin_password = $__file{/run/secrets/grafana_admin_password}


### PR DESCRIPTION
To generate correct links when running Grafana behind a reverse proxy, as we do.