### PR TITLE
perf(vibetype): add node modules volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,4 +314,8 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
     The message queue's data.
     
+ - ### `vibetype_data`
+    
+    The frontend's data.
+    
 

--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -571,6 +571,7 @@ services:
       - ${PNPM_STORE_DIR}:/srv/.pnpm-store/ #DARGSTACK-REMOVE
       - ./certificates/:/srv/certificates/ #DARGSTACK-REMOVE
       - ../../../vibetype/:/srv/app/ #DARGSTACK-REMOVE
+      - vibetype_data:/srv/app/node_modules #DARGSTACK-REMOVE
       - ./configurations/postgraphile/jwtRS256.key.pub:/run/environment-variables/NUXT_PUBLIC_VIO_AUTH_JWT_PUBLIC_KEY:ro
 version: "3.7"
 volumes:
@@ -603,4 +604,7 @@ volumes:
     {}
   redpanda_data:
     # The message queue's data.
+    {}
+  vibetype_data:
+    # The frontend's data.
     {}

--- a/src/production/production.yml
+++ b/src/production/production.yml
@@ -169,3 +169,4 @@ volumes:
     # The reverse proxy's certificate data.
     {}
   minio_data: (( prune ))
+  vibetype_data: (( prune ))


### PR DESCRIPTION
Cache vibetype's `node_modules` for faster development service startup and less friction with the host machine's `node_modules`.
