### PR TITLE
chore(traefik): fix nuxt virtual import issue

### DIFF
--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -460,6 +460,7 @@ services:
       - --api=true
       - --entryPoints.web.address=:80
       - --entryPoints.web-secure.address=:443
+      - --entryPoints.web-secure.http.encodedCharacters.allowEncodedSlash=true #DARGSTACK-REMOVE # required for Nuxt's virtual imports
       - --providers.swarm=true
       - --providers.swarm.endpoint=unix:///var/run/docker.sock
       - --providers.swarm.exposedByDefault=false


### PR DESCRIPTION
Traefik's new version added a [security feature](https://doc.traefik.io/traefik/v2.11/migration/v2/#encoded-characters-in-request-path) that conflicts with Nuxt in development. This PR works around this case.

cc @maevsi/contributors-active 