### PR TITLE
chore(deps): upgrade dargstack to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This project is deployed in accordance to the [DargStack template](https://githu
 
  - ### `adminer`
     
-    You can access the database's frontend at [adminer.localhost](https://adminer.localhost/).
+    You can access the database's frontend at [adminer.app.localhost](https://adminer.app.localhost/).
     This information is required for login:
     
     |          |                     |
@@ -203,7 +203,7 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
  - ### `grafana`
     
-    You can access the observation dashboard at [grafana.localhost](https://grafana.localhost/).
+    You can access the observation dashboard at [grafana.app.localhost](https://grafana.app.localhost/).
     
  - ### `jobber`
     
@@ -211,12 +211,12 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
  - ### `minio` ![development](https://img.shields.io/badge/-development-informational.svg?style=flat-square)
     
-    You can access the s3 console at [minio.localhost](https://minio.localhost/).
-    You can access the s3 api service at [s3.localhost](https://s3.localhost/) if you want to access via cli from outside the stack.
+    You can access the s3 console at [minio.app.localhost](https://minio.app.localhost/).
+    You can access the s3 api service at [s3.app.localhost](https://s3.app.localhost/) if you want to access via cli from outside the stack.
     
  - ### `portainer`
     
-    You can access the container manager's frontend at [portainer.localhost](https://portainer.localhost/).
+    You can access the container manager's frontend at [portainer.app.localhost](https://portainer.app.localhost/).
     
  - ### `portainer-agent`
     
@@ -224,7 +224,7 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
  - ### `postgraphile`
     
-    You can access the GraphQL API for the PostgreSQL database at [postgraphile.localhost](https://postgraphile.localhost/).
+    You can access the GraphQL API for the PostgreSQL database at [postgraphile.app.localhost](https://postgraphile.app.localhost/).
     
  - ### `postgres`
     
@@ -236,7 +236,7 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
  - ### `prometheus`
     
-    You can access the metrics monitoring at [prometheus.localhost](https://prometheus.localhost/).
+    You can access the metrics monitoring at [prometheus.app.localhost](https://prometheus.app.localhost/).
     
  - ### `reccoom`
     
@@ -252,7 +252,7 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
  - ### `redpanda-console`
     
-    You can access the event streaming platform's ui at [redpanda.localhost](https://redpanda.localhost/).
+    You can access the event streaming platform's ui at [redpanda.app.localhost](https://redpanda.app.localhost/).
     
  - ### `sqitch`
     
@@ -260,7 +260,7 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
  - ### `traefik`
     
-    You can access the reverse proxy's dashboard at [traefik.localhost](https://traefik.localhost/).
+    You can access the reverse proxy's dashboard at [traefik.app.localhost](https://traefik.app.localhost/).
     
  - ### `traefik_certs-dumper` ![production](https://img.shields.io/badge/-production-informational.svg?style=flat-square)
     
@@ -268,11 +268,11 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
  - ### `tusd`
     
-    You can access the upload service at [tusd.localhost](https://tusd.localhost/).
+    You can access the upload service at [tusd.app.localhost](https://tusd.app.localhost/).
     
  - ### `vibetype`
     
-    You can access the main project's frontend at [localhost](https://localhost/).
+    You can access the main project's frontend at [app.localhost](https://app.localhost/).
     
 
 ## volumes

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@commitlint/cli": "20.2.0",
     "@commitlint/config-conventional": "20.2.0",
     "conventional-changelog-conventionalcommits": "9.1.0",
-    "dargstack": "2.5.1",
+    "dargstack": "3.0.0",
     "dargstack_rgen": "0.9.77",
     "husky": "9.1.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 9.1.0
         version: 9.1.0
       dargstack:
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: 3.0.0
+        version: 3.0.0
       dargstack_rgen:
         specifier: 0.9.77
         version: 0.9.77
@@ -205,9 +205,9 @@ packages:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
     engines: {node: '>=12'}
 
-  dargstack@2.5.1:
-    resolution: {integrity: sha512-E+G0++n9MDgQu8B4BDQjvCE+ALdwT9Z373Wx4Oi7z3hpxtVjVO9eK/Ml6nk7BU1v3HZvTmVVCwY8q5Zl7i/JZQ==}
-    engines: {node: '22'}
+  dargstack@3.0.0:
+    resolution: {integrity: sha512-hJn6NSEDiDvkH+3THlnLGHyvxagrm+t7f1snRSNER0u5A+manl2Wy1A7oFq6tWGtBIj0DDVoT0llpMlh8R9xQw==}
+    engines: {node: '24'}
 
   dargstack_rgen@0.9.77:
     resolution: {integrity: sha512-6MCw/HamHfjBaKeuHPA8jCLTa3yqY1a1MkQ1BbbXUn6awqz++DCNFcjMV4m5KJZt2lIiPLfDxq29UIAtbfrJxg==}
@@ -711,7 +711,7 @@ snapshots:
 
   dargs@8.1.0: {}
 
-  dargstack@2.5.1: {}
+  dargstack@3.0.0: {}
 
   dargstack_rgen@0.9.77:
     dependencies:

--- a/src/development/certificates/mkcert.sh
+++ b/src/development/certificates/mkcert.sh
@@ -29,14 +29,14 @@ done
 
 create "root"
 create "traefik" \
-    `# adminer` "adminer.localhost" \
-    `# grafana` "grafana.localhost" \
-    `# minio` "minio.localhost" \
-    `# portainer` "portainer.localhost" \
-    `# postgraphile` "postgraphile.localhost" \
-    `# prometheus` "prometheus.localhost" \
-    `# reccoom` "reccoom.localhost" \
-    `# redpanda` "redpanda.localhost" \
-    `# traefik` "traefik.localhost" \
-    `# tusd` "tusd.localhost" \
-    `# vibetype` "localhost" "www.localhost" "127.0.0.1" "0.0.0.0"
+    `# adminer` "adminer.app.localhost" \
+    `# grafana` "grafana.app.localhost" \
+    `# minio` "minio.app.localhost" \
+    `# portainer` "portainer.app.localhost" \
+    `# postgraphile` "postgraphile.app.localhost" \
+    `# prometheus` "prometheus.app.localhost" \
+    `# reccoom` "reccoom.app.localhost" \
+    `# redpanda` "redpanda.app.localhost" \
+    `# traefik` "traefik.app.localhost" \
+    `# tusd` "tusd.app.localhost" \
+    `# vibetype` "app.localhost" "www.app.localhost" "127.0.0.1" "0.0.0.0"

--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -108,7 +108,7 @@ secrets:
     file: ./secrets/vibetype/turnstile-key.secret
 services:
   adminer:
-    # You can access the database's frontend at [adminer.localhost](https://adminer.localhost/).
+    # You can access the database's frontend at [adminer.app.localhost](https://adminer.app.localhost/).
     # This information is required for login:
     #
     # |          |                     |
@@ -170,7 +170,7 @@ services:
     # You cannot access the ip geolocator via a web interface.
     image: ghcr.io/observabilitystack/geoip-api:2025-31
   grafana:
-    # You can access the observation dashboard at [grafana.localhost](https://grafana.localhost/).
+    # You can access the observation dashboard at [grafana.app.localhost](https://grafana.app.localhost/).
     deploy:
       labels:
         - traefik.enable=true
@@ -221,8 +221,8 @@ services:
       - ../production/backups/postgres/:/backups/
       - ./configurations/jobber/.jobber:/home/jobberuser/.jobber:ro
   minio: #DARGSTACK-REMOVE
-    # You can access the s3 console at [minio.localhost](https://minio.localhost/).
-    # You can access the s3 api service at [s3.localhost](https://s3.localhost/) if you want to access via cli from outside the stack.
+    # You can access the s3 console at [minio.app.localhost](https://minio.app.localhost/).
+    # You can access the s3 api service at [s3.app.localhost](https://s3.app.localhost/) if you want to access via cli from outside the stack.
     entrypoint: /patched-entrypoint.sh #DARGSTACK-REMOVE
     command: server /data --console-address ":9001" #DARGSTACK-REMOVE
     deploy: #DARGSTACK-REMOVE
@@ -258,7 +258,7 @@ services:
       MINIO_ROOT_PASSWORD: s3password #DARGSTACK-REMOVE
       MINIO_ROOT_USER: s3user #DARGSTACK-REMOVE
   portainer:
-    # You can access the container manager's frontend at [portainer.localhost](https://portainer.localhost/).
+    # You can access the container manager's frontend at [portainer.app.localhost](https://portainer.app.localhost/).
     command: -H tcp://tasks.portainer-agent:9001 --tlsskipverify --admin-password-file '/run/secrets/portainer_admin-password'
     deploy:
       labels:
@@ -292,15 +292,16 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/volumes:/var/lib/docker/volumes
   postgraphile:
-    # You can access the GraphQL API for the PostgreSQL database at [postgraphile.localhost](https://postgraphile.localhost/).
+    # You can access the GraphQL API for the PostgreSQL database at [postgraphile.app.localhost](https://postgraphile.app.localhost/).
     deploy:
       labels:
         - traefik.enable=true
         - traefik.http.middlewares.postgraphile_auth.forwardauth.address=http://vibetype:3000/api/service/traefik/authentication
         - traefik.http.middlewares.postgraphile_auth.forwardauth.forwardBody=true
         - traefik.http.middlewares.postgraphile_auth.forwardauth.preserveRequestMethod=true
+        - traefik.http.middlewares.postgraphile_cors.headers.accessControlAllowCredentials=true
         - traefik.http.middlewares.postgraphile_cors.headers.accessControlAllowHeaders=authorization,baggage,content-type,sentry-trace,x-turnstile-key
-        - traefik.http.middlewares.postgraphile_cors.headers.accessControlAllowOriginList=*
+        - traefik.http.middlewares.postgraphile_cors.headers.accessControlAllowOriginList=https://${STACK_DOMAIN}
         - traefik.http.routers.postgraphile.entryPoints=web
         - traefik.http.routers.postgraphile.middlewares=redirectscheme #DARGSTACK-REMOVE
         - traefik.http.routers.postgraphile.rule=Host(`postgraphile.${STACK_DOMAIN}`)
@@ -347,7 +348,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data/
   prometheus:
-    # You can access the metrics monitoring at [prometheus.localhost](https://prometheus.localhost/).
+    # You can access the metrics monitoring at [prometheus.app.localhost](https://prometheus.app.localhost/).
     deploy:
       labels:
         - traefik.enable=true
@@ -423,7 +424,7 @@ services:
     volumes:
       - redpanda_data:/var/lib/redpanda/data
   redpanda-console:
-    # You can access the event streaming platform's ui at [redpanda.localhost](https://redpanda.localhost/).
+    # You can access the event streaming platform's ui at [redpanda.app.localhost](https://redpanda.app.localhost/).
     deploy:
       labels:
         - traefik.enable=true
@@ -455,7 +456,7 @@ services:
     volumes:
       - ../../../sqitch/:/srv/app/
   traefik:
-    # You can access the reverse proxy's dashboard at [traefik.localhost](https://traefik.localhost/).
+    # You can access the reverse proxy's dashboard at [traefik.app.localhost](https://traefik.app.localhost/).
     command:
       - --api=true
       - --entryPoints.web.address=:80
@@ -499,7 +500,7 @@ services:
       - ./certificates/:/etc/traefik/acme/
       - ./configurations/traefik/dynamic.yml:/dynamic.yml:ro #DARGSTACK-REMOVE
   tusd:
-    # You can access the upload service at [tusd.localhost](https://tusd.localhost/).
+    # You can access the upload service at [tusd.app.localhost](https://tusd.app.localhost/).
     command: -behind-proxy --hooks-enabled-events pre-create,pre-finish,pre-terminate --hooks-http http://vibetype:3000/api/internal/service/tusd -max-size ${TUSD_MAX_SIZE} -s3-bucket ${TUSD_BUCKET} -s3-endpoint ${TUSD_ENDPOINT}
     deploy:
       labels:
@@ -520,7 +521,7 @@ services:
       - source: tusd_aws
         target: /home/tusd/.aws/credentials
   vibetype:
-    # You can access the main project's frontend at [localhost](https://localhost/).
+    # You can access the main project's frontend at [app.localhost](https://app.localhost/).
     deploy:
       labels:
         - traefik.enable=true

--- a/src/production/production.yml
+++ b/src/production/production.yml
@@ -121,7 +121,7 @@ services:
     image: ghcr.io/maevsi/vibetype:12.37.0
     user: (( prune ))
   # vibetype_beta:
-  #   # You can access the main project frontend's beta version at [beta.localhost](https://beta.localhost/).
+  #   # You can access the main project frontend's beta version at [beta.app.localhost](https://beta.app.localhost/).
   #   deploy:
   #     labels:
   #       - traefik.enable=true


### PR DESCRIPTION
For development, dargstack v3 uses `app.localhost` instead of just `localhost`. That means vibetype will be available under `app.localhost` and other services like adminer under `adminer.app.localhost`.

@maevsi/contributors-active to migrate, run
- `dargstack self-update` (twice if you haven't run it within the last month) and
- `git pull` on this repo's main branch