### PR TITLE
feat(reccoom): add migration service

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,10 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
     You cannot access the recommendation service directly.
     
+ - ### `reccoom_migration`
+    
+    You cannot access the recommender's database migration service directly.
+    
  - ### `reccoom_postgres`
     
     You can access reccoom's database via `adminer`.

--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -567,6 +567,24 @@ services:
     volumes:
       - ../../../reccoom/:/srv/app/ #DARGSTACK-REMOVE
       - ./configurations/postgraphile/jwtES256.key.pub:/run/configurations/jwtES256.key.pub:ro
+  reccoom_migration:
+    # You cannot access the recommender's database migration service directly.
+    command: ["uv", "run", "alembic", "upgrade", "head"]
+    deploy:
+      restart_policy:
+        condition: on-failure
+    environment:
+      RECCOOM_POSTGRES_HOST: reccoom_postgres
+    image: maevsi/reccoom:dev
+    secrets:
+      - source: postgres_db
+        target: /run/environment-variables/RECCOOM_POSTGRES_DATABASE
+      - source: postgres_user
+        target: /run/environment-variables/RECCOOM_POSTGRES_USER
+      - source: postgres_password
+        target: /run/environment-variables/RECCOOM_POSTGRES_PASSWORD
+    volumes:
+      - ../../../reccoom/:/srv/app/ #DARGSTACK-REMOVE
   reccoom_postgres:
     # You can access reccoom's database via `adminer`.
     environment:


### PR DESCRIPTION
A service that applies reccoom's migrations until it succeeds, then it does not start again until updated.