### PR TITLE
fix(zammad): disable elasticsearch integration

### DIFF
--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -7,6 +7,7 @@ x-shared:
   zammad-service:
     &zammad-service # You can access the helpdesk at [zammad.app.localhost](https://zammad.app.localhost/).
     environment: &zammad-environment
+      ELASTICSEARCH_ENABLED: false
       ELASTICSEARCH_HOST: elasticsearch
       ELASTICSEARCH_SCHEMA: https
       ELASTICSEARCH_USER: elastic


### PR DESCRIPTION
Elasticsearch service is already scaled to 0, Zammad configuration adapts to that.