### PR TITLE
fix(vibetype): allow csrf header for cors

### DIFF
--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -762,7 +762,7 @@ services:
     deploy:
       labels:
         - traefik.enable=true
-        - traefik.http.middlewares.vibetype_cors.headers.accessControlAllowHeaders=authorization,content-type,hook-name,x-turnstile-key
+        - traefik.http.middlewares.vibetype_cors.headers.accessControlAllowHeaders=authorization,content-type,hook-name,x-csrf-token,x-turnstile-key
         - traefik.http.middlewares.vibetype_cors.headers.accessControlAllowMethods=GET,POST,PUT,DELETE
         - traefik.http.middlewares.vibetype_cors.headers.accessControlAllowOriginList=https://localhost:3000,https://app.localhost:3000
         - traefik.http.middlewares.vibetype_redirectregex.redirectregex.regex=^https?:\/\/www\.${STACK_DOMAIN}\/(.*)


### PR DESCRIPTION
This allows frontend-only development to work with the new security header.