### PR TITLE
feat(postgraphile): remove forward authentication middleware

### DIFF
--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -450,9 +450,6 @@ services:
     deploy:
       labels:
         - traefik.enable=true
-        - traefik.http.middlewares.postgraphile_auth.forwardauth.address=http://vibetype:3000/api/internal/service/postgraphile/authentication
-        - traefik.http.middlewares.postgraphile_auth.forwardauth.forwardBody=true
-        - traefik.http.middlewares.postgraphile_auth.forwardauth.preserveRequestMethod=true
         - traefik.http.middlewares.postgraphile_cors.headers.accessControlAllowCredentials=true
         - traefik.http.middlewares.postgraphile_cors.headers.accessControlAllowHeaders=authorization
         - traefik.http.middlewares.postgraphile_cors.headers.accessControlAllowOriginList=https://${STACK_DOMAIN},https://localhost:3000,https://app.localhost:3000
@@ -460,7 +457,7 @@ services:
         - traefik.http.routers.postgraphile.middlewares=redirectscheme #DARGSTACK-REMOVE
         - traefik.http.routers.postgraphile.rule=Host(`postgraphile.${STACK_DOMAIN}`)
         - traefik.http.routers.postgraphile_secure.entryPoints=web-secure
-        - traefik.http.routers.postgraphile_secure.middlewares=postgraphile_auth,postgraphile_cors
+        - traefik.http.routers.postgraphile_secure.middlewares=postgraphile_cors
         - traefik.http.routers.postgraphile_secure.rule=Host(`postgraphile.${STACK_DOMAIN}`) && Path(`/graphql`)
         - traefik.http.routers.postgraphile_secure.tls.options=mintls13@file #DARGSTACK-REMOVE
         - traefik.http.routers.postgraphile_secure_ruru.entryPoints=web-secure

--- a/src/production/production.yml
+++ b/src/production/production.yml
@@ -44,10 +44,10 @@ services:
     deploy:
       labels:
         - (( append ))
-        - traefik.http.routers.postgraphile.middlewares=postgraphile_auth,postgraphile_cors
+        - traefik.http.routers.postgraphile.middlewares=postgraphile_cors,redirectscheme
         - traefik.http.routers.postgraphile_secure.tls.certresolver=default
         - traefik.http.routers.postgraphile_secure_ruru.tls.certresolver=default
-    image: ghcr.io/maevsi/postgraphile:2.0.5
+    image: ghcr.io/maevsi/postgraphile:2.1.0
   postgres_backup:
     # You cannot access the database backup directly.
     environment:


### PR DESCRIPTION
There is now a Postgraphile preset which validates turnstile:
- https://github.com/maevsi/postgraphile/pull/21

Thus, the traefik middleware is no longer needed.