### PR TITLE
fix(reccoom): update cache volume mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ This project is deployed in accordance to the [DargStack template](https://githu
     
     The metrics monitoring's data.
     
- - ### `reccoom_fastembed_data`
+ - ### `reccoom_data`
     
     The recommender's model cache.
     

--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -578,7 +578,7 @@ services:
       - reccoom_data:/home/python/.cache/
   reccoom_consumer:
     # You can track the recommender's event streaming consumer using `redpanda-console`.
-    command: ["python", "-m", "src.consumer"]
+    command: ["uv", "run", "python", "-m", "src.consumer"]
     environment:
       KAFKA_BOOTSTRAP_SERVERS: redpanda:9092
       POSTGRES_HOST: postgres
@@ -607,7 +607,7 @@ services:
       - reccoom_data:/home/python/.cache/
   reccoom_migration:
     # You cannot access the recommender's database migration service directly.
-    command: ["python", "-m", "src.migration"]
+    command: ["uv", "run", "python", "-m", "src.migration"]
     deploy:
       restart_policy:
         condition: on-failure

--- a/src/development/stack.yml
+++ b/src/development/stack.yml
@@ -575,6 +575,7 @@ services:
     volumes:
       - ../../../reccoom/:/srv/app/ #DARGSTACK-REMOVE
       - ./configurations/postgraphile/jwtES256.key.pub:/run/configurations/jwtES256.key.pub:ro
+      - reccoom_data:/home/python/.cache/
   reccoom_consumer:
     # You can track the recommender's event streaming consumer using `redpanda-console`.
     command: ["python", "-m", "src.consumer"]
@@ -603,7 +604,7 @@ services:
         target: /run/environment-variables/SENTRY_DSN
     volumes:
       - reccoom_fastembed_data:/tmp/fastembed_cache/
-      - ../../../reccoom/:/srv/app/ #DARGSTACK-REMOVE
+      - reccoom_data:/home/python/.cache/
   reccoom_migration:
     # You cannot access the recommender's database migration service directly.
     command: ["python", "-m", "src.migration"]
@@ -624,6 +625,7 @@ services:
         target: /run/environment-variables/SENTRY_DSN
     volumes:
       - ../../../reccoom/:/srv/app/
+      - reccoom_data:/home/python/.cache/
   reccoom_postgres:
     # You can access reccoom's database via `adminer`.
     environment:
@@ -942,7 +944,7 @@ volumes:
   prometheus_data:
     # The metrics monitoring's data.
     {}
-  reccoom_fastembed_data:
+  reccoom_data:
     # The recommender's model cache.
     {}
   reccoom_postgres_data:

--- a/src/production/production.yml
+++ b/src/production/production.yml
@@ -72,15 +72,15 @@ services:
     deploy: (( prune ))
     environment:
       SENTRY_TRACES_SAMPLE_RATE: "0.1"
-    image: ghcr.io/maevsi/reccoom:0.18.7
+    image: ghcr.io/maevsi/reccoom:0.18.9
   reccoom_consumer:
     environment:
       SENTRY_TRACES_SAMPLE_RATE: "0.1"
-    image: ghcr.io/maevsi/reccoom:0.18.7
+    image: ghcr.io/maevsi/reccoom:0.18.9
   reccoom_migration:
     environment:
       SENTRY_TRACES_SAMPLE_RATE: "0.1"
-    image: ghcr.io/maevsi/reccoom:0.18.7
+    image: ghcr.io/maevsi/reccoom:0.18.9
     volumes: (( prune ))
   redpanda-console:
     deploy:


### PR DESCRIPTION
Update the cache volume mount for reccoom and reintroducing uv as python runner.