### PR TITLE
chore(dargstack): use platform overrides for mac compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
       - name: Regenerate docs
         run: |
-          go install github.com/dargstack/dargstack/v4/cmd/dargstack@v4.2.0
+          go install github.com/dargstack/dargstack/v4/cmd/dargstack@v4.7.0
           export PATH="$(go env GOPATH)/bin:$PATH"
           dargstack document
       - name: Commit and push updated docs

--- a/Dockerfile.md
+++ b/Dockerfile.md
@@ -1,3 +1,3 @@
 # <DEPENDENCIES>
-FROM ghcr.io/dargstack/dargstack:4.5.1
+FROM ghcr.io/dargstack/dargstack:4.7.0
 # </DEPENDENCIES>

--- a/dargstack.yaml
+++ b/dargstack.yaml
@@ -13,7 +13,7 @@ environment:
     # tag: latest # optional, defaults to "latest"
 
 metadata:
-  compatibility: ">=4.2.0-0 <5.0.0"
+  compatibility: ">=4.7.0-0 <5.0.0"
   name: "vibetype"
   source:
     name: "maevsi"

--- a/src/development/cadvisor/compose.yaml
+++ b/src/development/cadvisor/compose.yaml
@@ -23,3 +23,14 @@ services:
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
       - /dev/disk/:/dev/disk:ro
+x-dargstack:
+  platform:
+    darwin:
+      services:
+        cadvisor:
+          volumes:
+            - (( prune ))
+            - /:/rootfs:ro
+            - /var/run:/var/run:ro
+            - /sys:/sys:ro
+            - /var/lib/docker/:/var/lib/docker:ro

--- a/src/development/postgres/compose.yaml
+++ b/src/development/postgres/compose.yaml
@@ -74,6 +74,11 @@ volumes:
     # The database's data.
     {}
 x-dargstack:
+  platform:
+    darwin:
+      services:
+        postgres:
+          image: imresamu/postgis:18-3.6-alpine
   secrets:
     postgres-db:
       type: wordlist_word


### PR DESCRIPTION
This pull request updates the project to support Dargstack 4.7.0 and adds improved platform-specific configuration for Darwin (macOS) environments. The main changes include updating dependency versions, compatibility requirements, and adding platform-specific service definitions for `cadvisor` and `postgres`.

**Dependency and Compatibility Updates:**
* Updated the Dargstack base image version to `4.7.0` in `Dockerfile.md` to use the latest features and fixes.
* Updated the `compatibility` requirement in `dargstack.yaml` to `>=4.7.0-0 <5.0.0` to ensure alignment with the new Dargstack version.

**Platform-Specific Service Configuration (Darwin/macOS):**
* Added a Darwin-specific `x-dargstack` section for the `cadvisor` service in `src/development/cadvisor/compose.yaml` to configure appropriate volumes for macOS.
* Added a Darwin-specific `x-dargstack` section for the `postgres` service in `src/development/postgres/compose.yaml`, specifying a custom image for macOS compatibility.