### PR TITLE
feat(zammad)!: migrate to v7

### DIFF
--- a/src/development/elasticsearch/compose.yaml
+++ b/src/development/elasticsearch/compose.yaml
@@ -25,7 +25,7 @@ services:
     #   timeout: 10s
     #   retries: 3
     #   start_period: 60s
-    image: elasticsearch:8.19.19
+    image: elasticsearch:9.4.4
     secrets:
       - source: elasticsearch-keystore-password
         uid: "1000"

--- a/src/development/zammad/compose.yaml
+++ b/src/development/zammad/compose.yaml
@@ -16,7 +16,7 @@ x-shared:
       POSTGRESQL_HOST: postgres
       POSTGRESQL_OPTIONS: ?pool=50
       REDIS_URL: redis://redis:6379
-    image: ghcr.io/zammad/zammad:6.5.2-90
+    image: ghcr.io/zammad/zammad:7.1.1-0035
     secrets:
       - source: elasticsearch-password
         target: /run/environment-variables/ELASTICSEARCH_PASS
@@ -26,7 +26,7 @@ x-shared:
         target: /run/environment-variables/POSTGRESQL_PASS
     volumes:
       - zammad-data:/opt/zammad/storage
-      - ./configurations/docker-entrypoint.sh:/docker-entrypoint.sh:ro
+      - ./configurations/docker-entrypoint.sh:/opt/zammad/bin/docker-entrypoint:ro
 services:
   zammad-backup:
     # You cannot access the helpdesk backup service via a web interface.
@@ -36,7 +36,7 @@ services:
     volumes:
       - zammad-backup-data:/var/tmp/zammad
       - zammad-data:/opt/zammad/storage:ro
-      - ./configurations/docker-entrypoint.sh:/docker-entrypoint.sh:ro
+      - ./configurations/docker-entrypoint.sh:/opt/zammad/bin/docker-entrypoint:ro
   zammad-init:
     # You cannot access the helpdesk initialization service via a web interface.
     <<: *zammad-service

--- a/src/development/zammad/configurations/docker-entrypoint.sh
+++ b/src/development/zammad/configurations/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -o errexit
 
 # START of maevsi entrypoint script customization
 ENVIRONMENT_VARIABLES_PATH="/run/environment-variables"
@@ -45,46 +45,50 @@ load_environment_variables
 : "${NGINX_CLIENT_MAX_BODY_SIZE:=50M}"
 : "${NGINX_SERVER_NAME:=_}"
 : "${NGINX_SERVER_SCHEME:=\$scheme}"
-: "${POSTGRESQL_DB:=zammad_production}"
 : "${POSTGRESQL_DB_CREATE:=true}"
-: "${POSTGRESQL_HOST:=zammad-postgresql}"
-: "${POSTGRESQL_PORT:=5432}"
-: "${POSTGRESQL_USER:=zammad}"
-: "${POSTGRESQL_PASS:=zammad}"
-: "${POSTGRESQL_OPTIONS:=}"
-: "${RAILS_ENV:=production}"
-: "${RAILS_LOG_TO_STDOUT:=true}"
-: "${RAILS_TRUSTED_PROXIES:=127.0.0.1,::1}"
-: "${ZAMMAD_DIR:=/opt/zammad}"
 : "${ZAMMAD_RAILSSERVER_HOST:=zammad-railsserver}"
 : "${ZAMMAD_RAILSSERVER_PORT:=3000}"
 : "${ZAMMAD_WEBSOCKET_HOST:=zammad-websocket}"
 : "${ZAMMAD_WEBSOCKET_PORT:=6042}"
+: "${RESTORE_DIR:=/var/tmp/zammad/restore}"
 
-# Support both ZAMMAD_WEB_CONCURRENCY (as recommended by the Zammad docker stack & documentation)
-#   and WEB_CONCURRENCY (Zammad and Rails default).
-: "${ZAMMAD_WEB_CONCURRENCY:=0}"
-: "${WEB_CONCURRENCY:=${ZAMMAD_WEB_CONCURRENCY}}"
-export WEB_CONCURRENCY
-
-ESCAPED_POSTGRESQL_PASS=$(echo "$POSTGRESQL_PASS" | sed -e 's/[\/&]/\\&/g')
-export DATABASE_URL="postgres://${POSTGRESQL_USER}:${ESCAPED_POSTGRESQL_PASS}@${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DB}${POSTGRESQL_OPTIONS}"
+function check_no_restore_running {
+  echo 'Checking for active restore operations...'
+  until [ ! -d "${RESTORE_DIR}" ] || [ -z "$(ls "${RESTORE_DIR}")" ]; do
+    echo "  waiting for restore to finish..."
+    sleep 2
+  done
+}
 
 function check_zammad_ready {
+  check_no_restore_running
+
+  echo 'Checking if Zammad is ready...'
   # Verify that migrations have been ran and seeds executed to process ENV vars like FQDN correctly.
   until bundle exec rails r 'ActiveRecord::Migration.check_all_pending!; Translation.any? || raise' &> /dev/null; do
-    echo "waiting for init container to finish install or update..."
+    echo "  waiting for init container to finish install or update..."
     sleep 2
+  done
+}
+
+function check_postgresql_ready {
+  echo 'Checking if PostgreSQL is ready...'
+
+  # Strip possible surrounding brackets from IPv6 addresses.
+  CLEAN_POSTGRESQL_HOST=${POSTGRESQL_HOST#[}; CLEAN_POSTGRESQL_HOST=${CLEAN_POSTGRESQL_HOST%]}
+
+  until (pg_isready -q -h "$CLEAN_POSTGRESQL_HOST" -p "$POSTGRESQL_PORT"); do
+    echo "  waiting for postgresql server to be ready..."
+    sleep 1
   done
 }
 
 # zammad init
 if [ "$1" = 'zammad-init' ]; then
   # install / update zammad
-  until (echo > /dev/tcp/"${POSTGRESQL_HOST}"/"${POSTGRESQL_PORT}") &> /dev/null; do
-    echo "waiting for postgresql server to be ready..."
-    sleep 1
-  done
+  check_postgresql_ready
+
+  check_no_restore_running
 
   # check if database exists / update to new version
   echo "initialising / updating database..."
@@ -176,7 +180,7 @@ elif [ "$1" = 'zammad-nginx' ]; then
 elif [ "$1" = 'zammad-railsserver' ]; then
   check_zammad_ready
 
-  echo "starting railsserver... with WEB_CONCURRENCY=${WEB_CONCURRENCY}"
+  echo "starting railsserver..."
 
   #shellcheck disable=SC2101
   exec bundle exec puma -b tcp://[::]:"${ZAMMAD_RAILSSERVER_PORT}" -e "${RAILS_ENV}"
@@ -199,7 +203,7 @@ elif [ "$1" = 'zammad-websocket' ]; then
 
 # zammad-backup
 elif [ "$1" = 'zammad-backup' ]; then
-  check_zammad_ready
+  check_postgresql_ready
 
   echo "starting backup..."
 


### PR DESCRIPTION
This pull request updates the Zammad development environment to use newer versions of Zammad and Elasticsearch, and improves the Docker entrypoint script for better reliability and maintainability. The main changes are grouped below:

**Dependency Upgrades:**

* Updated Zammad Docker image from `6.5.2-90` to `7.1.1-0035` in `compose.yaml`, ensuring the development environment uses the latest features and security fixes.
* Updated Elasticsearch Docker image from `8.19.19` to `9.4.4` in `compose.yaml`.

**Entrypoint Script Improvements:**

* Replaced `set -e` with `set -o errexit` in `docker-entrypoint.sh` for improved error handling consistency.
* Refactored environment variable handling: removed redundant defaults, added `RESTORE_DIR`, and removed unnecessary `WEB_CONCURRENCY` logic.
* Added new functions `check_no_restore_running` and `check_postgresql_ready` to ensure no restore operations are active and that PostgreSQL is ready before proceeding with init or backup, improving robustness during startup.
* Changed backup service to check PostgreSQL readiness instead of Zammad readiness before starting.
* Simplified Rails server startup log output by removing `WEB_CONCURRENCY` reference.

**Docker Compose Volume Mounts:**

* Updated volume mount paths for `docker-entrypoint.sh` to match Zammad 7.x conventions (`/opt/zammad/bin/docker-entrypoint`) in both main service and backup service.