### PR TITLE
fix(node-exporter): set deploy.update_config.order

### DIFF
--- a/src/production/node-exporter/compose.yaml
+++ b/src/production/node-exporter/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  node-exporter:
+    deploy:
+      update_config:
+        order: start-first


### PR DESCRIPTION
## Summary
- Add a production override for `node-exporter` that sets `deploy.update_config.order` to `start-first`, matching the existing convention used by `cadvisor` and `portainer-agent`
- Resolves the `dargstack validate -e production` warning: `service:node-exporter: deploy.update_config.order is not set`

## Test plan
- [x] `dargstack validate -e production` passes with no warnings