### PR TITLE
feat(postgraphile): add turnstile secret

### DIFF
--- a/src/development/postgraphile/compose.yaml
+++ b/src/development/postgraphile/compose.yaml
@@ -47,6 +47,8 @@ services:
         target: /run/environment-variables/POSTGRAPHILE_OWNER_CONNECTION
       - source: postgraphile-sentry-dsn
         target: /run/environment-variables/SENTRY_DSN
+      - source: vibetype-turnstile-key
+        target: /run/environment-variables/POSTGRAPHILE_TURNSTILE_SECRET_KEY
     volumes:
       - ~~~/postgraphile/:/srv/app/ # dargstack:dev-only
       - ./configurations/jwtES256.key.pub:/run/environment-variables/POSTGRAPHILE_JWT_PUBLIC_KEY:ro


### PR DESCRIPTION
Wires the existing `vibetype-turnstile-key` secret into postgraphile's service as `POSTGRAPHILE_TURNSTILE_SECRET_KEY`, needed for the companion postgraphile PR that verifies Turnstile tokens directly instead of proxying through vibetype.