### PR TITLE
feat(debezium)!: consolidate cdc capture on the outbox table

### DIFF
--- a/src/development/debezium/configurations/entrypoint.sh
+++ b/src/development/debezium/configurations/entrypoint.sh
@@ -27,8 +27,18 @@ curl --fail --output /dev/null --silent --show-error \
     "database.password": "'"$POSTGRES_PASSWORD"'",
     "database.user": "'"$POSTGRES_USER"'",
     "plugin.name": "pgoutput",
-    "table.include.list": "vibetype.event,vibetype.upload,vibetype_private.notification",
-    "topic.prefix" : "vibetype"
+    "table.include.list": "vibetype_private.outbox,vibetype.upload",
+    "topic.prefix" : "vibetype",
+    "transforms": "outbox",
+    "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
+    "transforms.outbox.route.by.field": "channel",
+    "transforms.outbox.route.topic.replacement": "vibetype.outbox.${routedByValue}",
+    "transforms.outbox.table.field.event.key": "id",
+    "transforms.outbox.table.field.event.payload": "payload",
+    "transforms.outbox.predicate": "isOutbox",
+    "predicates": "isOutbox",
+    "predicates.isOutbox.type": "org.apache.kafka.connect.transforms.predicates.TopicNameMatches",
+    "predicates.isOutbox.pattern": "vibetype\\.vibetype_private\\.outbox"
 }'
 
 echo "PostgreSQL connector '$CONNECTOR_NAME' is up to date."

--- a/src/development/debezium/configurations/entrypoint.sh
+++ b/src/development/debezium/configurations/entrypoint.sh
@@ -31,7 +31,7 @@ curl --fail --output /dev/null --silent --show-error \
     "topic.prefix" : "vibetype",
     "transforms": "outbox",
     "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
-    "transforms.outbox.route.by.field": "channel",
+    "transforms.outbox.route.by.field": "aggregate_type",
     "transforms.outbox.route.topic.replacement": "vibetype.outbox.${routedByValue}",
     "transforms.outbox.table.field.event.key": "aggregate_id",
     "transforms.outbox.table.field.event.payload": "payload",

--- a/src/development/debezium/configurations/entrypoint.sh
+++ b/src/development/debezium/configurations/entrypoint.sh
@@ -27,7 +27,7 @@ curl --fail --output /dev/null --silent --show-error \
     "database.password": "'"$POSTGRES_PASSWORD"'",
     "database.user": "'"$POSTGRES_USER"'",
     "plugin.name": "pgoutput",
-    "table.include.list": "vibetype_private.outbox,vibetype.upload",
+    "table.include.list": "vibetype_private.outbox",
     "topic.prefix" : "vibetype",
     "transforms": "outbox",
     "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",

--- a/src/development/debezium/configurations/entrypoint.sh
+++ b/src/development/debezium/configurations/entrypoint.sh
@@ -33,7 +33,7 @@ curl --fail --output /dev/null --silent --show-error \
     "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
     "transforms.outbox.route.by.field": "channel",
     "transforms.outbox.route.topic.replacement": "vibetype.outbox.${routedByValue}",
-    "transforms.outbox.table.field.event.key": "id",
+    "transforms.outbox.table.field.event.key": "aggregate_id",
     "transforms.outbox.table.field.event.payload": "payload",
     "transforms.outbox.predicate": "isOutbox",
     "predicates": "isOutbox",


### PR DESCRIPTION
Points the Debezium connector's `table.include.list` at `vibetype_private.outbox` instead of capturing `vibetype.event` directly, and adds the `EventRouter` SMT, scoped to the outbox topic via a predicate, to route and unwrap outbox events by channel. `vibetype.upload` stays on direct capture since it has another consumer. Depends on the sqitch outbox rename.